### PR TITLE
#14 Lazy expire, heap for same

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -45,6 +45,8 @@ extern bool SILENT;
 
 #define DB_ERR_KEY_NOTEXIST     4   // Key entry not present
 #define DB_ERR_CMD_NOTEXIST     5   // Cmd sent does not exist
+#define DB_ERR_KEY_EXPIRED      6   // For Lazy removal (internal use)
+#define DB_ERR_KEY_NOT_EXPIRED  7   // For Lazy removal (internal use)
 
 #define DB_ERR_EXIT             41  // EXIT signal for evnet loop
 

--- a/include/hash.h
+++ b/include/hash.h
@@ -9,6 +9,7 @@ typedef struct Entry {
     struct Entry *next;
     struct Entry *prev;
     time_t expiry;          // when the KV is to be purged
+    size_t heap_index;      // for efficicent random removal
 } Entry;
 
 typedef struct HashTable {

--- a/include/ttl.h
+++ b/include/ttl.h
@@ -4,6 +4,9 @@
 #include "common.h"
 #include "hash.h"
 
+// Forward declaration of Entry to ensure it's recognized
+typedef struct Entry Entry;
+
 // STRUCT (min-heap) for storing pointers of eligible KVs
 
 typedef struct ttl_node {
@@ -37,7 +40,11 @@ bool compare_ttl(ttl_node *a, ttl_node *b);
 
 void heapify(ttl_heap *h, size_t i);
 
+// To add element in the ttl heap [used by hash_update_expiry]
 err_t heap_insert(ttl_heap *h, Entry *e);
+
+// For removing element before expiry
+err_t heap_remove(ttl_heap *h, Entry *e);
 
 /*
 Removes the entry of the expired KV from the TTL heap


### PR DESCRIPTION
Key gets removed if its `EXPIRY` time is less than or equal to the current UNIX time
```
sahDB> set a a
Added key a and value a in DB
sahDB> save
Data from disk written to data.safe
```
`data.safe:`
```sh
{
   "count": 1,
   "size": 31,
   "data": [
       {"bucket":4, "entries":a:a|-1},
   ]
}
```
After setting `EXPIRE` field
```
sahDB> expire a 10
Updated expiry time of key a
sahDB> save
Data from disk written to data.safe
```
`data.safe:`
```sh
{
   "count": 1,
   "size": 31,
   "data": [
       {"bucket":4, "entries":a:a|1763568321},
   ]
}
```
After expiration
```
sahDB> exists a
FALSE
sahDB> save
Data from disk written to data.safe
sahDB>
```
`data.safe:`
```
{
   "count": 0,
   "size": 31,
   "data": [
   ]
}
```