### PR TITLE
Added option to get stuff from config file [#17], can get expire UNIX time of key using

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ __pycache__/
 # Python debug logs
 pexpect.debug.log
 **/pexpect.debug.log
+
+# Misc
+todo*

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,10 @@ clean:
 	@rm -rf {pexpect_debug.log,test/{*pyc*}}
 	@rm -fr cppcheck*
 
-cleanlogs:
+cleanall:
 	@rm -rf {pexpect_debug.log,test/{*pyc*}}
 	@rm -fr cppcheck*
+	@rm -fr cscope* tags*
 
 
 check:

--- a/include/config.h
+++ b/include/config.h
@@ -1,6 +1,55 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#include "common.h"
+
+// --configfile=
+#define MIN_CONFIG_LEN 13
+#define CONFIG_PREFIX "--configfile="
+#define DEFAULT_SERVER_CONFIG_FILE "sahdb.conf"
+
+/* 
+Log config
+LOG_INFO    -> 0
+LOG_DEBUG   -> 1
+LOG_EXCEPT  -> 2
+LOG_TRACE   -> 3
+*/
+typedef enum log_level {
+    LOG_INFO,
+    LOG_DEBUG,
+    LOG_EXCEPT,
+    LOG_TRACE
+} log_level;
+
+/*
+This log serves like an append file for every CRUD op performed
+NO_LOG      -> 0 (No log updation done for WRITE op)
+LOG_ONCE    -> 1 (Update the log every sec if WRITE op performed) 
+LOG_ALL     -> 2 (Update the log after every WRITE op)
+*/
+typedef enum crud_op_log_level {
+    NO_LOG,
+    LOG_ONCE,
+    LOG_ALL
+} crud_op_log_level;
+// Server config
+typedef struct server_config {
+    log_level   server_log_level;   // Level of the server log
+    char        *server_log_file;   // Path of the server log
+    char        *config_file;       // Path of --configfile
+    int         server_port;        // Port to run server on, NULL if non-server
+    char        *savefile;          // Path of the dump file (SAVE related)
+    bool        rebuild;            // Flag to build from savefile
+} server_config;
+
+// extern server_config host_config;
+
+// typedef struct node_config {
+//     log_level node_log_level;
+// } node_config;
+
+
 
 typedef struct  {
     int input_fd;
@@ -11,4 +60,9 @@ extern AppConfig app_config;
 
 void init_app_config(int fd_in, int fd_out);
 
+/*
+This method builds up the internal config params based on the config file passed
+on with the --configfile flag on start-up or else continues with the default file
+*/
+err_t init_server_config(int argc, char **argv);
 #endif

--- a/include/dbsave.h
+++ b/include/dbsave.h
@@ -2,11 +2,15 @@
 #define DBSAVE_H
 
 #include "common.h"
+#include "config.h"
 #include "hash.h"
+
+extern server_config host_config;
 
 #define META_LEN 50
 #define KV_LEN 1024
-#define SAVE_FILE "data.safe"
+#define DEFAULT_SAVE_FILE "data.safe"
+#define SAVE_FILE host_config.savefile
 #define FILE_HEADER_VER "SahDB001"
 #define FILE_HEADER_LEN 8
 

--- a/include/hash.h
+++ b/include/hash.h
@@ -25,7 +25,31 @@ typedef struct HashTable {
 void ht_init();
 err_t hash_insert(char *, char *);
 err_t hash_get(char *);
+// this method returns the KV entry and is for INTERNAL USE ONLY
+Entry* hash_get_kv(char *);
+
+/*
+Info: Fetches expiry of KV from HT
+Input: Key (char*)
+Resp: UNIX expiry time if expiry is set
+Return: (0=>Expiry Exists, 4=>Key does not exist)
+*/
+err_t hash_get_expiry(char *);
+
+/*
+Info: Verifies existence of KV in HT
+Input: Key (char*)
+Resp: TRUE||FALSE based on existence
+Return: (0=>Exists, 4=>Key does not exist)
+*/
 err_t hash_exists(char *);
+
+/*
+Info: Removes entry of KV from HT
+Input: Key (char*)
+Resp: Confirmation of deletion|Log in case non-existent Key
+Return: (0=>YES, 4=>Key does not exist)
+*/
 err_t hash_delete(char *);
 err_t hash_update_expiry(char *, time_t);
 // err_t ht_set

--- a/network/c/network.c
+++ b/network/c/network.c
@@ -1,7 +1,7 @@
 #include "network.h"
 
 
-void run_c_server(int port) {
+void run_as_server(int port) {
     // server FD
     int server_fd = socket(AF_INET, SOCK_STREAM, 0);
     if (server_fd == -1) {
@@ -29,7 +29,7 @@ void run_c_server(int port) {
         goto ret;
     }
 
-    sprintf(resp, "C server running on port %d", port);
+    sprintf(resp, "Server running on port %d", port);
     send_info_to_user(resp);
     free(resp);
     resp = NULL;
@@ -79,24 +79,20 @@ void eventLoop(){
 }
 
 int main(int argc, char** argv) {
+    // initialize internal config variables
+    init_server_config(argc, argv);
     ht_init();
     ttl_init();
     if(ht == NULL)
         return -1;
-    // ./exec --port XXXX
-    if (argc == 3) {
-        // running on network?
-        if (strcmp(argv[1], "--port")==0) {
-            int port = atoi(argv[2]);
-            run_c_server(port);
-        }
-        // rebuilding from file?
-        if (strcmp(argv[1], "--savefile")==0) {
-            rebuild_from_savefile();
-            eventLoop();
-        }
+    if (host_config.rebuild) {
+        rebuild_from_savefile();
+        host_config.rebuild = false;
     }
-    else
+    if (host_config.server_port) {
+        run_as_server(host_config.server_port);
+    } else {
         eventLoop();
+    }
     return 0;
 }

--- a/network/c/network.h
+++ b/network/c/network.h
@@ -13,6 +13,7 @@
 extern void run_c_server(int port);
 
 extern HashTable *ht;
+extern server_config host_config;
 
 #define MAX_REQ_IN_Q    10
 #define DEFAULT_PORT    5000

--- a/src/command.c
+++ b/src/command.c
@@ -45,15 +45,21 @@ ret:
 // ########### GET command ###########
 err_t get_val_from_key_helper(int argc, char **cmd_arr) {
     err_t res = 0;
-    if (argc!=2) {
+    if (argc<2) {
         char err[100];
         sprintf(err, "%sIncorrect number of args passed, run HELP GET%s", RED, RESET);
         send_info_to_user(err);
         res = DB_ERR_INVAILD_ARGS;
         goto ret;
     }
-    char *key = cmd_arr[1];
-    res = hash_get(key);
+    if (argc == 2) {
+        char *key = cmd_arr[1];
+        res = hash_get(key);
+    }
+    if (argc == 3 && !strcasecmp(cmd_arr[2], "ex")) {
+        char *key = cmd_arr[1];
+        res = hash_get_expiry(key);
+    }
 ret:
     return res;
 }
@@ -147,9 +153,10 @@ err_t expire_key_val(int argc, char **cmd_arr) {
     char *key = cmd_arr[1];
     long expiry = (long)atol(cmd_arr[2]);
     SILENT = true;
-    int key_exists = hash_exists(key);
+    int key_exists_in_ht = hash_exists(key);
     SILENT = false;
-    res = hash_update_expiry(key, expiry);
+    if (key_exists_in_ht == 0)
+        res = hash_update_expiry(key, expiry);
 ret:
     return res;
 }

--- a/src/common.c
+++ b/src/common.c
@@ -21,7 +21,7 @@ err_t get_user_input(char *buf) {
     return 0;
 }
 
-// changed to write to given stream
+// For sharing information with user
 void send_info_to_user(const char *data) {
     // do nothing if call from method for internal use
     if (SILENT)

--- a/src/config.c
+++ b/src/config.c
@@ -1,9 +1,114 @@
 #include "config.h"
 #include "common.h"
+#include "dbsave.h"
 
 AppConfig app_config;
+server_config host_config;
+
+// Trim leading and trailing whitespace in-place.
+// Returns pointer to trimmed string start.
+static char* trim(char *s) {
+    char *end;
+
+    // Trim leading spaces
+    while (isspace((unsigned char)*s)) s++;
+    // If string is all spaces, return empty string
+    if (*s == 0)
+        return s;
+    // Trim trailing spaces
+    end = s + strlen(s) - 1;
+    while (end > s && isspace((unsigned char)*end)) end--;
+    // Write terminating null
+    *(end + 1) = '\0';
+    return s;
+}
 
 void init_app_config(int fd_in, int fd_out) {
     app_config.input_fd = (fd_in > 0) ? fd_in : STDIN_FILENO;
     app_config.output_fd = (fd_out > 0) ? fd_in : STDOUT_FILENO;
+}
+
+static err_t load_server_config() {
+    err_t res = DB_ERR_OK;
+    char resp[MAX_RESP_LEN];
+    FILE *fp = fopen(host_config.config_file, "r");
+    if (fp == NULL) {
+        res = DB_ERR_GENERIC_FAIL;
+        sprintf(resp, "Unable to access file %s, setting to default", host_config.config_file);
+        host_config.savefile = DEFAULT_SAVE_FILE;
+        goto ret;
+    }
+    // keeping line to max 512 chars for now
+    char line[MAX_CMD_LEN];
+    while (fgets(line, MAX_CMD_LEN, fp)) {
+        line[strcspn(line, "\n")] = '\0';
+        // Find the position of '=' in the line
+        char *equal_sign_pos = strchr(line, '=');
+        if (equal_sign_pos != NULL) {
+            *equal_sign_pos = '\0';  // Split the string at the '='
+            char *field = trim(line);
+            char *value = trim(equal_sign_pos + 1);
+            char field_resp[MAX_RESP_LEN];
+            // Print the field and value (can be stored in a dictionary here)
+            sprintf(field_resp, "Field: '%s', Value: '%s'", field, value);
+            if (strcasecmp(field, "port") == 0 && atoi(value) > 0) {
+                host_config.server_port = atoi(value);
+            } else if (strcasecmp(field, "savefile") == 0) {
+                FILE *save_ptr = fopen(value, "r");
+                if (save_ptr == NULL){
+                    sprintf(resp, "Unable to access file %s, setting to default", value);
+                    res = DB_ERR_GENERIC_FAIL;
+                    host_config.savefile = DEFAULT_SAVE_FILE;
+                    continue;
+                }
+                host_config.savefile = value;
+                host_config.rebuild = true;
+            } else {
+                continue;
+            }
+            send_info_to_user(field_resp);
+        }
+    }
+ret:
+    send_info_to_user(resp);
+    return res;
+}
+
+err_t init_server_config(int argc, char **argv) {
+    err_t ret = DB_ERR_OK;
+    host_config.server_log_level = LOG_INFO;
+    host_config.server_log_file = NULL;
+    host_config.config_file = NULL;
+    char resp[100];
+    // conf file exists
+    for(int i=0; i < argc; i++) {
+        if (strlen(argv[i]) >= MIN_CONFIG_LEN) {
+            if (strncmp(argv[i], CONFIG_PREFIX, MIN_CONFIG_LEN) == 0) {
+                char *fname = strtok(argv[i], "=");
+                fname = strtok(NULL, "");
+                host_config.config_file = fname;
+                load_server_config();
+                sprintf(resp, "Config %s, loaded :)", host_config.config_file);
+                send_info_to_user(resp);
+            }
+        }
+        if (strcmp(argv[i], "--port") == 0 && i+1 < argc) {
+            host_config.server_port = atoi(argv[i+1]);
+        }
+        if (strcmp(argv[i], "--savefile") == 0 && i+1 < argc) {
+            FILE *save_ptr = fopen(argv[i+1], "r");
+            if (save_ptr == NULL){
+                sprintf(resp, "Not able to access file %s :(", argv[i+1]);
+                send_info_to_user(resp);
+                ret = DB_ERR_GENERIC_FAIL;
+                // setting save file to the default name
+                host_config.savefile = DEFAULT_SAVE_FILE;
+                continue;
+            }
+            host_config.savefile = argv[i+1];
+            host_config.rebuild = true;
+        }
+    }
+    // create attribute list from config file
+    return ret;
 }

--- a/test.conf
+++ b/test.conf
@@ -1,0 +1,4 @@
+## comment
+
+port = 5050
+savefile = data.safe


### PR DESCRIPTION
- Added option to write settings to config file and parse it while running:
```bash
sah@localhost:~/code/sahDB/build>  ./sahDB --configfile=../test.conf
Field: 'port', Value: '5051'
Not able to access file data.safe :(
Config ../test.conf, loaded :)
Server running on port 5051
sah@localhost:~/code/sahDB/build>  ./sahDB --configfile=../test.conf
Field: 'port', Value: '5050'
Field: 'savefile', Value: 'data.safe'

Config ../test.conf, loaded :)
FILE READ!
Server running on port 5050
```
Sample config file
```conf
## comment

port = 5050
savefile = data.safe
```

- User can get expire time of key in UNIX time
```bash
sah@localhost:~/code/sahDB/build>  ./sahDB
sahDB> set a a
Added key a and value a in DB
sahDB> get a
a
sahDB> get a ex
No expiry set for a
sahDB> expire a 5000
Updated expiry time of key a
sahDB> get a ex
Expiry at UNIX time 1764776700
sahDB> expire a -1
Updated expiry time of key a
sahDB> get a ex
Value corresponding to key a not present in DB
sahDB> exit
Exiting ...
```